### PR TITLE
fix links for keycard docummentation

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -29,8 +29,7 @@
               <a href="#why" title="Why" class="js-anchor-scroll o-navigation__item">Why</a>
               <a href="#features" title="Features" class="js-anchor-scroll o-navigation__item">Features</a>
               <a href="#security" title="Security" class="js-anchor-scroll o-navigation__item">Security</a>
-              <a href="#keycard-api" title="Keycard API" class="js-anchor-scroll
-              o-navigation__item">Keycard API</a>
+              <a href="#keycard-api" title="Keycard API" class="js-anchor-scroll o-navigation__item">Keycard API</a>
               <a href="about-us.html" title="About us" class="o-navigation__item">About us</a>
               <a href="#form-preorder" title="Pre-Order" class="js-popup o-navigation__item"><span class="a-button a-button--rounded">Pre-Order</span></a>
             </div>
@@ -47,7 +46,7 @@
                 <a href="#form-preorder" class="js-popup a-button" title="Pre-Order">Pre-Order</a>
               </div>
               <div class="o-actionbar__item">
-                <a href="https://keycard.status.im/api/" class="a-button a-button--ghost">See documentation</a>
+                <a href="https://status.im/keycard_api/" class="a-button a-button--ghost">See documentation</a>
               </div>
             </div>
           </div>
@@ -203,7 +202,7 @@
             <div class="o-grid__column-1-1 o-grid__column-large-1-2">
               <img src="images/security-keyvisual.png" alt="" class="js-inviewport-item a-zoom">
               <div class="o-center">
-                <a href="https://keycard.status.im/api/" title="See the docs" class="a-button">See the docs</a>
+                <a href="https://status.im/keycard_api/" title="See the docs" class="a-button">See the docs</a>
               </div>
             </div>
             <div class="o-grid__column-1-1 o-grid__column-large-1-2">
@@ -240,7 +239,7 @@
               <div class="o-distance-small">
                 <div class="o-actionbar">
                   <div class="o-actionbar__item">
-                    <a href="https://keycard.status.im/api/" target="_blank" class="a-button a-button--negative">See the Docs</a>
+                    <a href="https://status.im/keycard_api/" target="_blank" class="a-button a-button--negative">See the Docs</a>
                   </div>
                   <div class="o-actionbar__item">
                     <a href="https://github.com/status-im/status-keycard" target="_blank" class="a-button a-button--negative">Github Repo</a>
@@ -303,9 +302,9 @@
           <div class="o-grid__column-1-2 o-grid__column-large-1-4 o-grid__column-xlarge-1-5">
             <p class="h6">Documentation</p>
             <ul class="o-list">
-              <li><a href="https://keycard.status.im/api/" target="_blank" title="Getting started">Getting started</a></li>
-              <li><a href="https://keycard.status.im/api/sdk_installation.html" title="Java SDK" target="_blank">Java SDK</a></li>
-              <li><a href="https://keycard.status.im/api/apdu_overview.html" title="Protocol" target="_blank">Protocol</a></li>
+              <li><a href="https://status.im/keycard_api/" target="_blank" title="Getting started">Getting started</a></li>
+              <li><a href="https://status.im/keycard_api/sdk_installation.html" title="Java SDK" target="_blank">Java SDK</a></li>
+              <li><a href="https://status.im/keycard_api/apdu_overview.html" title="Protocol" target="_blank">Protocol</a></li>
             </ul>
           </div>
           <div class="o-grid__column-1-2 o-grid__column-large-1-4 o-grid__column-xlarge-1-5">


### PR DESCRIPTION
Updates links to take into account the moving of keycard api docs to the main site in https://github.com/status-im/status.im/pull/239.